### PR TITLE
ci: revert to autofix-ci/action

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -3,23 +3,23 @@ name: autofix.ci
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: ["main"]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   autofix:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@c336a2788d9774dccfdeb4823a5058ccc9f07453 # v4.3.0
+      - uses: pnpm/action-setup@v4
         with:
           version: 10.18.3
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
@@ -28,6 +28,4 @@ jobs:
 
       - run: pnpm lint:fix
 
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
-        with:
-          commit_message: "style: auto-fix lint issues"
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -3,7 +3,7 @@ name: autofix.ci
 on:
   pull_request:
   push:
-    branches: ["main"]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions workflow configuration to use newer action references and improved security permissions by reducing repository write access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->