### PR TITLE
refactor: type .mdx module without `any` and remove duplicate declara…

### DIFF
--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -1,9 +1,0 @@
-import type { ComponentProps } from "react";
-
-declare module "*.mdx" {
-  // Extend div props with a custom `title` prop
-  type MDXProps = ComponentProps<"div"> & { title?: string };
-
-  const MDXComponent: (props: MDXProps) => JSX.Element;
-  export default MDXComponent;
-}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,6 +2,6 @@
 import type { ComponentType } from "react";
 
 declare module "*.mdx" {
-  const MDXComponent: ComponentType<any>;
+  const MDXComponent: ComponentType<Record<string, unknown>>;
   export default MDXComponent;
 }


### PR DESCRIPTION
…tion

Replace the `ComponentType<any>` fallback in types/global.d.ts with `ComponentType<Record<string, unknown>>` so no untyped `any` leaks into the ambient MDX module declaration.

Remove the duplicate `declare module "*.mdx"` block from app/global.d.ts. No code in the repo imports `.mdx` files directly as React components (all MDX is compiled at runtime via next-mdx-remote), so keeping a single typed declaration in types/global.d.ts is sufficient and avoids the conflicting module augmentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for imported MDX components by replacing unrestricted props with a more specific type.
  * Removed a redundant MDX type declaration to streamline type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->